### PR TITLE
fix: escape JSON braces in value_prompt template

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -205,7 +205,7 @@ OUTPUT FORMAT:
 
 Your output is ONLY in JSON. The structure looks like this:
 
-{
+{{
     "one-sentence-summary": "The one-sentence summary.",
     "labels": "The labels that apply from the set of options above.",
     "rating:": "S Tier: (Must Consume Original Content This Week) (or whatever the
@@ -213,7 +213,7 @@ Your output is ONLY in JSON. The structure looks like this:
     "rating-explanation:": "The explanation given for the rating.",
     "quality-score": "The numeric quality score",
     "quality-score-explanation": "The explanation for the quality score.",
-}
+}}
 
 OUTPUT INSTRUCTIONS
 


### PR DESCRIPTION
The value_prompt template in config.toml.example contained unescaped JSON braces that caused template parsing errors when used with Python's .format() method. Fixed by escaping all JSON braces while preserving the {content} placeholder.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)