### PR TITLE
fix: Remove duplicate URL links in markdown output

### DIFF
--- a/rssidian/core.py
+++ b/rssidian/core.py
@@ -732,10 +732,6 @@ class RSSProcessor:
                 # Add the article with a clean heading (no anchor)
                 summary_items.append(f"### {article.title}")
                 summary_items.append(f"*{feed_name} | {date_display} | {tier_display}*")
-                
-                # Add the URL to the original content
-                if article.url:
-                    summary_items.append(f"\n{article.url}\n")
 
                 if article.summary:
                     summary_items.append(f"\n{article.summary}\n")


### PR DESCRIPTION
Removes duplicate URL display in summary_items section since URLs are already included in the aggregated_summary section, eliminating double links in the final markdown output.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)