### PR TITLE
feat: update AI cost stats to use inline frontmatter format

### DIFF
--- a/rssidian/cost_tracker.py
+++ b/rssidian/cost_tracker.py
@@ -159,11 +159,11 @@ def format_cost_summary() -> str:
     
     summary = [
         "AI Cost Summary:",
-        f"  API Calls: {costs['api_calls']}",
-        f"  Prompt Tokens: {costs['prompt_tokens']}",
-        f"  Completion Tokens: {costs['completion_tokens']}",
-        f"  Total Tokens: {costs['total_tokens']}",
-        f"  Total Cost: ${costs['total_cost']:.6f}"
+        f"  API Calls:: {costs['api_calls']}",
+        f"  Prompt Tokens:: {costs['prompt_tokens']}",
+        f"  Completion Tokens:: {costs['completion_tokens']}",
+        f"  Total Tokens:: {costs['total_tokens']}",
+        f"  Total Cost:: ${costs['total_cost']:.6f}"
     ]
     
     # Add model-specific information if available


### PR DESCRIPTION
This PR updates the AI cost statistics formatting to use inline frontmatter format by adding double colons for specific fields.

## Changes
- Modified `format_cost_summary()` in `rssidian/cost_tracker.py`
- Changed single colons to double colons for: API Calls, Prompt Tokens, Completion Tokens, Total Tokens, Total Cost
- Kept "Cost by Model" section unchanged with single colons

Fixes #8

Generated with [Claude Code](https://claude.ai/code)