### PR TITLE
feat: add Ingestion_Date frontmatter to digest output

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -9,7 +9,7 @@ vault_path = "~/Documents/Obsidian"
 filename_template = "RSS Digest {from_date} to {to_date}"
 
 # Template for generated digest note
-# Available variables: {date_range}, {summary_items}, {value_analysis}, {feed_stats}, {aggregated_summary}, {cost_summary}
+# Available variables: {date_range}, {summary_items}, {value_analysis}, {feed_stats}, {aggregated_summary}, {cost_summary}, {ingestion_date}
 template = """# Feed Digest
 
 ## Aggregated Overview by Subject
@@ -23,6 +23,8 @@ template = """# Feed Digest
 
 ## Cost Summary
 {cost_summary}
+
+Ingestion_Date:: {ingestion_date}
 """
 
 [search]

--- a/rssidian/markdown.py
+++ b/rssidian/markdown.py
@@ -93,7 +93,8 @@ def write_digest_to_obsidian(digest: Dict[str, Any], config: Config) -> Optional
         feed_stats=digest["feed_stats"],
         aggregated_summary=digest.get("aggregated_summary", "No aggregated summary available."),
         cost_summary=format_cost_summary() or "No cost information available.",
-        filename=digest.get("filename", filename_without_extension)
+        filename=digest.get("filename", filename_without_extension),
+        ingestion_date=current_date
     )
     
     # Write to file


### PR DESCRIPTION
Add Ingestion_Date:: frontmatter field to generated digest files with YYYY-MM-DD format.
The field appears at the bottom after the cost summary section as requested.

- Add ingestion_date parameter to template formatting in markdown.py
- Update example template to include new Ingestion_Date:: field
- Document new {ingestion_date} variable in template comments

Fixes #11

Generated with [Claude Code](https://claude.ai/code)