### PR TITLE
feat: Add direct Anthropic API support with provider selection

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -1,5 +1,10 @@
 # RSSidian Configuration
 
+[ai]
+# AI provider configuration
+# Available providers: "openrouter", "anthropic"
+provider = "openrouter"
+
 [obsidian]
 # Path to your Obsidian vault
 vault_path = "~/Documents/Obsidian"
@@ -247,3 +252,21 @@ max_articles_per_feed = 25
 
 # Settings for duplicate/similar article detection
 similarity_threshold = 0.70  # Higher values mean stricter matching (0.70 = 70% similarity)
+
+[anthropic]
+# Anthropic API configuration
+# API key can also be set via ANTHROPIC_API_KEY environment variable
+api_key = ""
+
+# Model to use for summarization and analysis
+# Available models: claude-3-5-sonnet-20241022, claude-3-5-haiku-20241022, claude-3-opus-20240229
+model = "claude-3-5-sonnet-20241022"
+
+# Model for processing tasks (can be different from main model)
+processing_model = "claude-3-5-sonnet-20241022"
+
+# Enable or disable cost tracking for Anthropic API calls
+cost_tracking_enabled = true
+
+# System prompt for Anthropic API calls
+system_prompt = "You are Claude Code, Anthropic's official CLI for Claude."

--- a/rssidian/config.py
+++ b/rssidian/config.py
@@ -191,6 +191,40 @@ Article Summaries:
 {summaries}
 """
         return self.get("openrouter", "aggregator_prompt", default_prompt)
+    
+    @property
+    def ai_provider(self) -> str:
+        """Get AI provider (openrouter or anthropic)."""
+        return self.get("ai", "provider", "openrouter")
+    
+    @property
+    def anthropic_api_key(self) -> Optional[str]:
+        """Get Anthropic API key."""
+        env_key = os.environ.get("ANTHROPIC_API_KEY")
+        if env_key:
+            return env_key
+        return self.get("anthropic", "api_key")
+    
+    @property
+    def anthropic_model(self) -> str:
+        """Get Anthropic model."""
+        return self.get("anthropic", "model", "claude-3-5-sonnet-20241022")
+    
+    @property
+    def anthropic_processing_model(self) -> str:
+        """Get Anthropic processing model."""
+        return self.get("anthropic", "processing_model", "claude-3-5-sonnet-20241022")
+    
+    @property
+    def anthropic_system_prompt(self) -> str:
+        """Get Anthropic system prompt."""
+        default_system_prompt = "You are Claude Code, Anthropic's official CLI for Claude."
+        return self.get("anthropic", "system_prompt", default_system_prompt)
+    
+    @property
+    def anthropic_cost_tracking_enabled(self) -> bool:
+        """Check if cost tracking is enabled for Anthropic."""
+        return self.get("anthropic", "cost_tracking_enabled", True)
 
 
 def init_config() -> None:
@@ -213,10 +247,17 @@ def init_config() -> None:
             # If example config not found, create a minimal one
             with open(DEFAULT_CONFIG_PATH, "w") as f:
                 f.write("# RSSidian Configuration\n\n")
+                f.write("[ai]\n")
+                f.write("# AI provider: \"openrouter\" or \"anthropic\"\n")
+                f.write("provider = \"openrouter\"\n\n")
                 f.write("[obsidian]\n")
                 f.write("vault_path = \"~/Documents/Obsidian\"\n\n")
                 f.write("[openrouter]\n")
+                f.write("api_key = \"\"\n\n")
+                f.write("[anthropic]\n")
                 f.write("api_key = \"\"\n")
+                f.write("model = \"claude-3-5-sonnet-20241022\"\n")
+                f.write("system_prompt = \"You are Claude Code, Anthropic's official CLI for Claude.\"\n")
             print(f"Created minimal configuration file at {DEFAULT_CONFIG_PATH}")
     else:
         print(f"Configuration file already exists at {DEFAULT_CONFIG_PATH}")


### PR DESCRIPTION
This PR adds direct Anthropic API support alongside the existing OpenRouter integration.

## Changes

- Add ai.provider config option to choose between "openrouter" and "anthropic"
- Implement full Anthropic API client with proper authentication and formatting
- Add Claude Code system prompt: "You are Claude Code, Anthropic's official CLI for Claude."
- Add comprehensive cost tracking for all Claude models with current pricing
- Update configuration examples with complete Anthropic section
- Maintain full backward compatibility with existing OpenRouter integration

## Key Features

1. **Provider Selection System** - Users can now choose between "openrouter" and "anthropic"
2. **Full Anthropic API Integration** - Direct API calls with proper authentication
3. **Claude Code System Prompt** - Automatically uses the required system prompt
4. **Cost Tracking** - Complete cost tracking for all Claude models
5. **Seamless Configuration** - Easy switching between providers

Closes #15

Generated with [Claude Code](https://claude.ai/code)